### PR TITLE
Arguments vs parameters

### DIFF
--- a/_posts/2015-08-04-conventions-casing.md
+++ b/_posts/2015-08-04-conventions-casing.md
@@ -38,7 +38,7 @@ There are some [Microsoft guidelines to casing](https://msdn.microsoft.com/en-us
 ### Camel
 
 * Private members
-* Method arguments
+* Method parameters
 * Local variables
 
 ### Pascal 


### PR DESCRIPTION
The method parameters would be FooBar(string foo, int bar).

The method arguments would be FooBar("something", 1);

I think if I'm right you would want the parameters to be cased correctly (the arguments are what they are).
